### PR TITLE
Use @" register instead of @s

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -11,9 +11,6 @@ function! VisualStarSearchSet(cmdtype,...)
     let @" = escape(@", a:cmdtype.'\*')
   endif
   let @/ = substitute(@", '\n', '\\n', 'g')
-  if !a:0 || a:1 != 'raw'
-    let @" = '\V' . @"
-  endif
   let @" = temp
 endfunction
 


### PR DESCRIPTION
Previously `gv"sy` yanked not only into register `@s`, but also into register `@"`, while only `@s` gets restored afterwards.

To confirm this, yank some text into `@"` with `yiw`, visually select and search some other text `v$*` and paste with `p`. This will not paste the originally yanked word.

This pull request uses and restores the `@"` register instead. The above example pastes the originally yanked word as expected.
