### PR TITLE
Remove unused code

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -11,9 +11,6 @@ function! VisualStarSearchSet(cmdtype,...)
     let @s = escape(@s, a:cmdtype.'\*')
   endif
   let @/ = substitute(@s, '\n', '\\n', 'g')
-  if !a:0 || a:1 != 'raw'
-    let @s = '\V' . @s
-  endif
   let @s = temp
 endfunction
 


### PR DESCRIPTION
This code seems to be unnecessary.  It is operating on `@s` after it has
already been used to create `@/`.  The value in `@s` is changed right
before it is overwritten.

Thinking that this may be a bug I tried changing `let @s = '\V' . @s` to
`let @/ = '\V' . @/`, but this broke visual `<leader>*` (specifically on the
`**` line 12 in the test-patterns).  It seems this code is obsolete.
