### PR TITLE
fix search strings that have a selected square bracket

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -11,6 +11,7 @@ function! VisualStarSearchSet(cmdtype,...)
     let @" = escape(@", a:cmdtype.'\*')
   endif
   let @/ = substitute(@", '\n', '\\n', 'g')
+  let @/ = substitute(@/, '\[', '\\[', 'g')
   let @" = temp
 endfunction
 


### PR DESCRIPTION
example:
in some text search for something between square brackets, do `va[` and then *.