### PR TITLE
make search strings that have tilde work properly

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -12,6 +12,7 @@ function! VisualStarSearchSet(cmdtype,...)
   endif
   let @/ = substitute(@", '\n', '\\n', 'g')
   let @/ = substitute(@/, '\[', '\\[', 'g')
+  let @/ = substitute(@/, '\~', '\\~', 'g')
   let @" = temp
 endfunction
 


### PR DESCRIPTION
same as last patch, this fixes stuff that contain a tilde, we probably need to do this with all the characters that have special meaning, and/or do some sort of global escaping to search for the exact string and not use it as a regular expression.