### PR TITLE
Escape .

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -13,6 +13,7 @@ function! VisualStarSearchSet(cmdtype,...)
   let @/ = substitute(@", '\n', '\\n', 'g')
   let @/ = substitute(@/, '\[', '\\[', 'g')
   let @/ = substitute(@/, '\~', '\\~', 'g')
+  let @/ = substitute(@/, '\.', '\\.', 'g')
   let @" = temp
 endfunction
 

--- a/test-patterns
+++ b/test-patterns
@@ -12,6 +12,8 @@ don't
 **
 a[bc]d
 g~re
+hello.
+helloo
 
 don't
 'don't'
@@ -21,3 +23,5 @@ don't
 **
 a[bc]d
 g~re
+hello.
+helloo


### PR DESCRIPTION
With these changes `.` is escaped, so it is not interpreted as regex.