### PR TITLE
preserve "* register's content

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -6,6 +6,7 @@
 " search string, vim's search highlight will be wrong.  Refactor plz.
 function! VisualStarSearchSet(cmdtype,...)
   let temp = @"
+  let starRegisterContent = @*
   normal! gvy
   if !a:0 || a:1 != 'raw'
     let @" = escape(@", a:cmdtype.'\*')
@@ -15,6 +16,7 @@ function! VisualStarSearchSet(cmdtype,...)
   let @/ = substitute(@/, '\~', '\\~', 'g')
   let @/ = substitute(@/, '\.', '\\.', 'g')
   let @" = temp
+  let @* = starRegisterContent
 endfunction
 
 " replace vim's built-in visual * and # behavior


### PR DESCRIPTION
At the moment, when we do visual star search, `""` register's content is saved before search and restored after it.

If we set `unnamed` to `clipboard` option, (from `:help clipboard`) `""` register is the same as the `"*` register. This leads to the problem, where this plugin changes (via `normal! gvy` command) not only `""` register, but `"*` too. When we restore `""` register, `"*` register is not affected, so it's not restored, unlike standard vim's `*` behaviour.

This PR resolves described issue by saving `"*` register's content and restoring it later (just like we do for `""`)