### PR TITLE
feat: Support for Ripgrep if exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ to your .vimrc.
 
 ### Ripgrep
 
-If installed, Ripgrep is used instead of the default `vimgrep`. Internally, the `:Rg` command is used.
+If installed, Ripgrep is used instead of the default `vimgrep`.
 
-This can be exposed by i.e. [`fzf.vim`](https://github.com/junegunn/fzf.vim) or [`vim-ripgrep`](https://github.com/jremmen/vim-ripgrep).
+The `:Rg` command is used internally. That can be exposed by i.e. [`fzf.vim`](https://github.com/junegunn/fzf.vim) or [`vim-ripgrep`](https://github.com/jremmen/vim-ripgrep).
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ visual-star-search to use Ag instead of vimgrep, add
 [these two lines](https://github.com/bronson/dotfiles/blob/a3ab0d6ee8d9e5e7f6e12444753330bab0200b0e/.vimrc#L344-L345)
 to your .vimrc.
 
+### Ripgrep
+
+If installed, Ripgrep is used instead of the default `vimgrep`. Internally, the `:Rg` command is used.
+
+This can be exposed by i.e. [`fzf.vim`](https://github.com/junegunn/fzf.vim) or [`vim-ripgrep`](https://github.com/jremmen/vim-ripgrep).
 
 ### Install
 

--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -21,11 +21,22 @@ endfunction
 xnoremap * :<C-u>call VisualStarSearchSet('/')<CR>/<C-R>=@/<CR><CR>
 xnoremap # :<C-u>call VisualStarSearchSet('?')<CR>?<C-R>=@/<CR><CR>
 
-" recursively vimgrep for word under cursor or selection
-if maparg('<leader>*', 'n') == ''
-  nnoremap <leader>* :execute 'noautocmd vimgrep /\V' . substitute(escape(expand("<cword>"), '\'), '\n', '\\n', 'g') . '/ **'<CR>
-endif
-if maparg('<leader>*', 'v') == ''
-  vnoremap <leader>* :<C-u>call VisualStarSearchSet('/')<CR>:execute 'noautocmd vimgrep /' . @/ . '/ **'<CR>
-endif
+if exists(":Rg") "Fzf or similar wrapped ripgrep command
+  if maparg('<leader>*', 'n') == ''
+    nnoremap <leader>* :execute 'noautocmd Rg ' . substitute(escape(expand("<cword>"), '\'), '\n', '\\n', 'g') . ''<CR>
+  endif
+  if maparg('<leader>*', 'v') == ''
+    vnoremap <leader>* :<C-u>call VisualStarSearchSet('/')<CR>:execute 'noautocmd Rg ' . @/ . ''<CR>
+  endif
 
+else "Vimgrep
+
+  " recursively vimgrep for word under cursor or selection
+  if maparg('<leader>*', 'n') == ''
+    nnoremap <leader>* :execute 'noautocmd vimgrep /\V' . substitute(escape(expand("<cword>"), '\'), '\n', '\\n', 'g') . '/ **'<CR>
+  endif
+  if maparg('<leader>*', 'v') == ''
+    vnoremap <leader>* :<C-u>call VisualStarSearchSet('/')<CR>:execute 'noautocmd vimgrep /' . @/ . '/ **'<CR>
+  endif
+
+endif


### PR DESCRIPTION
This leverages the `:Rg` command which can be exposed by i.e. [`fzf.vim`](https://github.com/junegunn/fzf.vim) or [`vim-ripgrep`](https://github.com/jremmen/vim-ripgrep).
Resolves: https://github.com/bronson/vim-visual-star-search/issues/15.